### PR TITLE
swap out CookbookSite classes for Supermarket classes

### DIFF
--- a/lib/chef/knife/artifactory_show.rb
+++ b/lib/chef/knife/artifactory_show.rb
@@ -1,10 +1,10 @@
 
 require 'chef/knife'
-require 'chef/knife/cookbook_site_show'
+require 'chef/knife/supermarket_show'
 
 class Chef
   class Knife
-    class ArtifactoryShow < Knife::CookbookSiteShow
+    class ArtifactoryShow < Knife::SupermarketShow
 
       dependency_loaders.concat(superclass.dependency_loaders)
       options.merge!(superclass.options)

--- a/lib/chef/knife/knife_art_download.rb
+++ b/lib/chef/knife/knife_art_download.rb
@@ -1,15 +1,15 @@
-# Overrides the default Chef::Knife::CookbookSiteShare to allow basic authentication against an Artifactory backend.
+# Overrides the default Chef::Knife::SupermarketShare to allow basic authentication against an Artifactory backend.
 # Ideally we would like to use a mechanism that allows injecting pluggable authentication middleware into the Chef::Http
 # REST clients, but in the interest of allowing not-only-newest knife client versions to work with Artifactory we chose
 # this solution for now.
 
 require 'chef/knife'
-require 'chef/knife/cookbook_site_download'
+require 'chef/knife/supermarket_download'
 require 'knife-art/knife_art_utils'
 
 class Chef
   class Knife
-    class ArtifactoryDownload < Knife::CookbookSiteDownload
+    class ArtifactoryDownload < Knife::SupermarketDownload
 
       dependency_loaders.concat(superclass.dependency_loaders)
       options.merge!(superclass.options)

--- a/lib/chef/knife/knife_art_install.rb
+++ b/lib/chef/knife/knife_art_install.rb
@@ -1,15 +1,15 @@
-# Overrides the default Chef::Knife::CookbookSiteInstall to allow basic authentication against an Artifactory backend.
+# Overrides the default Chef::Knife::SupermarketInstall to allow basic authentication against an Artifactory backend.
 # Ideally we would like to use a mechanism that allows injecting pluggable authentication middleware into the Chef::Http
 # REST clients, but in the interest of allowing not-only-newest knife client versions to work with Artifactory we chose
 # this solution for now.
 
 
 require 'chef/knife'
-require 'chef/knife/cookbook_site_install'
+require 'chef/knife/supermarket_install'
 
 class Chef
   class Knife
-    class ArtifactoryInstall < Knife::CookbookSiteInstall
+    class ArtifactoryInstall < Knife::SupermarketInstall
 
       dependency_loaders.concat(superclass.dependency_loaders)
       options.merge!(superclass.options)

--- a/lib/chef/knife/knife_art_list.rb
+++ b/lib/chef/knife/knife_art_list.rb
@@ -1,10 +1,10 @@
 
 require 'chef/knife'
-require 'chef/knife/cookbook_site_list'
+require 'chef/knife/supermarket_list'
 
 class Chef
   class Knife
-    class ArtifactoryList < Knife::CookbookSiteList
+    class ArtifactoryList < Knife::SupermarketList
 
       dependency_loaders.concat(superclass.dependency_loaders)
       options.merge!(superclass.options)

--- a/lib/chef/knife/knife_art_search.rb
+++ b/lib/chef/knife/knife_art_search.rb
@@ -1,10 +1,10 @@
 
 require 'chef/knife'
-require 'chef/knife/cookbook_site_search'
+require 'chef/knife/supermarket_search'
 
 class Chef
   class Knife
-    class ArtifactorySearch < Knife::CookbookSiteSearch
+    class ArtifactorySearch < Knife::SupermarketSearch
 
       dependency_loaders.concat(superclass.dependency_loaders)
       options.merge!(superclass.options)

--- a/lib/chef/knife/knife_art_share.rb
+++ b/lib/chef/knife/knife_art_share.rb
@@ -2,7 +2,7 @@
 # 1. allow passing flags to the super class so that the do_upload method of this
 #    class is called and that signing key verification is skipped by the underlying Chef::HTTP::Authenticator that's
 #    used with the rest client (see comment below).
-# 2. Override (monkey patch) the required methods in Chef::HTTP::Authenticator and Knife::CookbookSiteShare
+# 2. Override (monkey patch) the required methods in Chef::HTTP::Authenticator and Knife::SupermarketShare
 #    to allow inserting our own logic that deploys a cookbook to Artifactory.
 #
 # The Supermarket API is kept (post /api/v1/cookbooks/cookbook_name) by Artifactory although it does not currently
@@ -10,11 +10,11 @@
 
 
 require 'chef/knife'
-require 'chef/knife/cookbook_site_share'
+require 'chef/knife/supermarket_share'
 
 class Chef
   class Knife
-    class ArtifactoryShare < Knife::CookbookSiteShare
+    class ArtifactoryShare < Knife::SupermarketShare
 
       dependency_loaders.concat(superclass.dependency_loaders)
       options.merge!(superclass.options)

--- a/lib/chef/knife/knife_art_unshare.rb
+++ b/lib/chef/knife/knife_art_unshare.rb
@@ -1,4 +1,4 @@
-# More or less copy-pasted from cookbook_site_unshare because the http call happens inside the run method, not much
+# More or less copy-pasted from supermarket_unshare because the http call happens inside the run method, not much
 # sense in extending it
 
 require 'chef/knife'

--- a/lib/knife-art/version.rb
+++ b/lib/knife-art/version.rb
@@ -1,3 +1,3 @@
 module KnifeArt
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
`CookbookSite` classes and commands will be [deprecated in Chef 16](https://github.com/chef/chef/commit/2a52b0208a4f22ff2eed04da980d9c32c175e122#diff-a7f4e0db5758adbeaf59ace8af1c756d) (due out in April 2020). Those classes are [essentially delegates](https://github.com/chef/chef/commit/5b90d09398021b0c6f6dac2081c1d884c8270f51#diff-a7f4e0db5758adbeaf59ace8af1c756d) for the `Supermarket` equivalents. So, this swaps out the parent classes for `Artifactory` classes to be the "proper" `Supermarket` classes.

Resolves #9 

Based entirely off the work of [Jason Barnett](https://github.com/jasonwbarnett/knife-artifactory/commit/9ae050bba760bea89451a9b737b49733e6c514f8) and [Baurzhan Konurbayev](https://github.com/jasonwbarnett/knife-artifactory/commit/eca9bf4093259a9a9a5287494698ae63a33cae78)